### PR TITLE
Core Data: fetch one author-scoped autosave in getAutosave

### DIFF
--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -397,7 +397,7 @@ _Returns_
 
 ### getAutosaves
 
-Returns the latest autosaves for the post.
+Returns the latest autosave(s) for the post.
 
 May return multiple autosaves since the backend stores one autosave per author for each post.
 
@@ -406,6 +406,7 @@ _Parameters_
 -   _state_ `State`: State tree.
 -   _postType_ `string`: The type of the parent post.
 -   _postId_ `EntityRecordKey`: The id of the parent post.
+-   _perPage_ `number`: The number of autosaves to retrieve. Optional, default is 1.
 
 _Returns_
 

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -397,7 +397,7 @@ _Returns_
 
 ### getAutosaves
 
-Returns the latest autosave(s) for the post.
+Returns the latest autosaves for the post.
 
 May return multiple autosaves since the backend stores one autosave per author for each post.
 
@@ -406,7 +406,6 @@ _Parameters_
 -   _state_ `State`: State tree.
 -   _postType_ `string`: The type of the parent post.
 -   _postId_ `EntityRecordKey`: The id of the parent post.
--   _perPage_ `number`: The number of autosaves to retrieve. Optional, default is 1.
 
 _Returns_
 

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -597,10 +597,10 @@ export const canUserEditEntityRecord =
  *
  * @param {string} postType The type of the parent post.
  * @param {number} postId   The id of the parent post.
- * @param {number} perPage  The number of autosaves to retrieve. Optional, default is 1.
+ * @param {number} perPage  The number of autosaves to retrieve. Optional.
  */
 export const getAutosaves =
-	( postType, postId, perPage = 1 ) =>
+	( postType, postId, perPage ) =>
 	async ( { dispatch, resolveSelect } ) => {
 		const {
 			rest_base: restBase,
@@ -610,9 +610,13 @@ export const getAutosaves =
 		if ( ! supports?.autosave ) {
 			return;
 		}
+		let path = `/${ restNamespace }/${ restBase }/${ postId }/autosaves?context=edit`;
+		if ( perPage ) {
+			path = path + `&per_page=${ perPage }`;
+		}
 
 		const autosaves = await apiFetch( {
-			path: `/${ restNamespace }/${ restBase }/${ postId }/autosaves?context=edit&per_page=${ perPage }`,
+			path,
 		} );
 
 		if ( autosaves && autosaves.length ) {
@@ -632,7 +636,7 @@ export const getAutosaves =
 export const getAutosave =
 	( postType, postId ) =>
 	async ( { resolveSelect } ) => {
-		await resolveSelect.getAutosaves( postType, postId );
+		await resolveSelect.getAutosaves( postType, postId, 1 );
 	};
 
 export const __experimentalGetCurrentGlobalStylesId =

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -597,9 +597,10 @@ export const canUserEditEntityRecord =
  *
  * @param {string} postType The type of the parent post.
  * @param {number} postId   The id of the parent post.
+ * @param {number} perPage  The number of autosaves to retrieve. Optional, default is 1.
  */
 export const getAutosaves =
-	( postType, postId ) =>
+	( postType, postId, perPage = 1 ) =>
 	async ( { dispatch, resolveSelect } ) => {
 		const {
 			rest_base: restBase,
@@ -611,7 +612,7 @@ export const getAutosaves =
 		}
 
 		const autosaves = await apiFetch( {
-			path: `/${ restNamespace }/${ restBase }/${ postId }/autosaves?context=edit`,
+			path: `/${ restNamespace }/${ restBase }/${ postId }/autosaves?context=edit&per_page=${ perPage }`,
 		} );
 
 		if ( autosaves && autosaves.length ) {

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -628,11 +628,23 @@ export const getAutosaves =
  * long-lived post with many editors, the difference is the entire collection
  * versus one row.
  *
- * `getAutosaves` is intentionally left alone rather than being narrowed, so
- * calling it directly still returns the full collection. Its resolution is
- * marked finished here because `hasFetchedAutosaves` reports on it, and
- * `isEditedPostAutosaveable` in @wordpress/editor treats an unfinished
- * resolution as "not yet known" — without this, autosaving would never enable.
+ * The `getAutosaves` resolver itself is left unchanged. This one reports
+ * completion against the `getAutosaves` resolution key because that is what
+ * `hasFetchedAutosaves` reads, and the editor package's
+ * `isEditedPostAutosaveable` treats an unfinished resolution as "not yet
+ * known" — without it, autosaving would never enable.
+ *
+ * That report happens in a `finally` so it covers every exit path. The previous
+ * delegation to `getAutosaves` completed its resolution unconditionally, and a
+ * failed request still counted as finished (`hasFinishedResolution` treats
+ * `error` as complete). Reporting only on the success path would leave
+ * autosaving disabled for the rest of the session after a single early return
+ * or network failure.
+ *
+ * Note that reporting against `getAutosaves` also suppresses that resolver for
+ * the post: `hasStartedResolution` becomes true, so a later direct call to the
+ * `getAutosaves` selector returns whatever this resolver stored rather than
+ * refetching the full collection.
  *
  * @param {string} postType The type of the parent post.
  * @param {number} postId   The id of the parent post.
@@ -641,36 +653,38 @@ export const getAutosaves =
 export const getAutosave =
 	( postType, postId, authorId ) =>
 	async ( { dispatch, resolveSelect } ) => {
-		if ( authorId === undefined ) {
-			return;
+		try {
+			if ( authorId === undefined ) {
+				return;
+			}
+
+			const {
+				rest_base: restBase,
+				rest_namespace: restNamespace = 'wp/v2',
+				supports,
+			} = await resolveSelect.getPostType( postType );
+
+			if ( ! supports?.autosave ) {
+				return;
+			}
+
+			const autosaves = await apiFetch( {
+				path: addQueryArgs(
+					`/${ restNamespace }/${ restBase }/${ postId }/autosaves`,
+					{
+						context: 'edit',
+						per_page: 1,
+						author: authorId,
+					}
+				),
+			} );
+
+			if ( autosaves && autosaves.length ) {
+				dispatch.receiveAutosaves( postId, autosaves );
+			}
+		} finally {
+			dispatch.finishResolution( 'getAutosaves', [ postType, postId ] );
 		}
-
-		const {
-			rest_base: restBase,
-			rest_namespace: restNamespace = 'wp/v2',
-			supports,
-		} = await resolveSelect.getPostType( postType );
-
-		if ( ! supports?.autosave ) {
-			return;
-		}
-
-		const autosaves = await apiFetch( {
-			path: addQueryArgs(
-				`/${ restNamespace }/${ restBase }/${ postId }/autosaves`,
-				{
-					context: 'edit',
-					per_page: 1,
-					author: authorId,
-				}
-			),
-		} );
-
-		if ( autosaves && autosaves.length ) {
-			dispatch.receiveAutosaves( postId, autosaves );
-		}
-
-		dispatch.finishResolution( 'getAutosaves', [ postType, postId ] );
 	};
 
 export const __experimentalGetCurrentGlobalStylesId =

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -597,10 +597,9 @@ export const canUserEditEntityRecord =
  *
  * @param {string} postType The type of the parent post.
  * @param {number} postId   The id of the parent post.
- * @param {number} perPage  The number of autosaves to retrieve. Optional.
  */
 export const getAutosaves =
-	( postType, postId, perPage ) =>
+	( postType, postId ) =>
 	async ( { dispatch, resolveSelect } ) => {
 		const {
 			rest_base: restBase,
@@ -610,13 +609,9 @@ export const getAutosaves =
 		if ( ! supports?.autosave ) {
 			return;
 		}
-		let path = `/${ restNamespace }/${ restBase }/${ postId }/autosaves?context=edit`;
-		if ( perPage ) {
-			path = path + `&per_page=${ perPage }`;
-		}
 
 		const autosaves = await apiFetch( {
-			path,
+			path: `/${ restNamespace }/${ restBase }/${ postId }/autosaves?context=edit`,
 		} );
 
 		if ( autosaves && autosaves.length ) {
@@ -625,18 +620,57 @@ export const getAutosaves =
 	};
 
 /**
- * Request autosave data from the REST API.
+ * Requests a single author's autosave from the REST API.
  *
- * This resolver exists to ensure the underlying autosaves are fetched via
- * `getAutosaves` when a call to the `getAutosave` selector is made.
+ * WordPress stores at most one autosave per author, and the `getAutosave`
+ * selector only ever returns the one belonging to the given author, so this
+ * requests that single record instead of every autosave for the post. On a
+ * long-lived post with many editors, the difference is the entire collection
+ * versus one row.
+ *
+ * `getAutosaves` is intentionally left alone rather than being narrowed, so
+ * calling it directly still returns the full collection. Its resolution is
+ * marked finished here because `hasFetchedAutosaves` reports on it, and
+ * `isEditedPostAutosaveable` in @wordpress/editor treats an unfinished
+ * resolution as "not yet known" — without this, autosaving would never enable.
  *
  * @param {string} postType The type of the parent post.
  * @param {number} postId   The id of the parent post.
+ * @param {number} authorId The id of the autosave author.
  */
 export const getAutosave =
-	( postType, postId ) =>
-	async ( { resolveSelect } ) => {
-		await resolveSelect.getAutosaves( postType, postId, 1 );
+	( postType, postId, authorId ) =>
+	async ( { dispatch, resolveSelect } ) => {
+		if ( authorId === undefined ) {
+			return;
+		}
+
+		const {
+			rest_base: restBase,
+			rest_namespace: restNamespace = 'wp/v2',
+			supports,
+		} = await resolveSelect.getPostType( postType );
+
+		if ( ! supports?.autosave ) {
+			return;
+		}
+
+		const autosaves = await apiFetch( {
+			path: addQueryArgs(
+				`/${ restNamespace }/${ restBase }/${ postId }/autosaves`,
+				{
+					context: 'edit',
+					per_page: 1,
+					author: authorId,
+				}
+			),
+		} );
+
+		if ( autosaves && autosaves.length ) {
+			dispatch.receiveAutosaves( postId, autosaves );
+		}
+
+		dispatch.finishResolution( 'getAutosaves', [ postType, postId ] );
 	};
 
 export const __experimentalGetCurrentGlobalStylesId =

--- a/packages/core-data/src/test/autosaves.js
+++ b/packages/core-data/src/test/autosaves.js
@@ -124,6 +124,58 @@ describe( 'autosaves', () => {
 		} );
 	} );
 
+	it( 'reports hasFetchedAutosaves after a failed request', async () => {
+		const registry = createTestRegistry();
+		triggerFetch.mockImplementation( ( { path, parse } ) => {
+			if ( path.startsWith( '/wp/v2/types' ) ) {
+				const postType = {
+					slug: 'post',
+					rest_base: 'posts',
+					rest_namespace: 'wp/v2',
+					supports: { autosave: true },
+				};
+
+				if ( parse === false ) {
+					return {
+						json: async () => postType,
+						headers: { get: () => '' },
+					};
+				}
+
+				return postType;
+			}
+
+			throw new Error( 'Network error' );
+		} );
+
+		await registry
+			.resolveSelect( coreDataStore )
+			.getAutosave( 'post', POST_ID, AUTHOR_ID )
+			.catch( () => {} );
+
+		// Autosaving must not stay disabled for the session after one failure.
+		expect(
+			registry
+				.select( coreDataStore )
+				.hasFetchedAutosaves( 'post', POST_ID )
+		).toBe( true );
+	} );
+
+	it( 'reports hasFetchedAutosaves when the author is not yet known', async () => {
+		const registry = createTestRegistry();
+		mockFetch( [ AUTOSAVE ] );
+
+		await registry
+			.resolveSelect( coreDataStore )
+			.getAutosave( 'post', POST_ID, undefined );
+
+		expect(
+			registry
+				.select( coreDataStore )
+				.hasFetchedAutosaves( 'post', POST_ID )
+		).toBe( true );
+	} );
+
 	it( 'does not return another author’s autosave', async () => {
 		const registry = createTestRegistry();
 		mockFetch( [ { id: 100, author: 999, parent: POST_ID } ] );

--- a/packages/core-data/src/test/autosaves.js
+++ b/packages/core-data/src/test/autosaves.js
@@ -1,0 +1,141 @@
+/**
+ * WordPress dependencies
+ */
+import triggerFetch from '@wordpress/api-fetch';
+import { createRegistry } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { store as coreDataStore } from '../index';
+
+jest.mock( '@wordpress/api-fetch' );
+
+describe( 'autosaves', () => {
+	const AUTHOR_ID = 7;
+	const POST_ID = 1;
+	const AUTOSAVE = { id: 99, author: AUTHOR_ID, parent: POST_ID };
+
+	/**
+	 * `getAutosave` resolves the post type first, which routes through
+	 * `getEntityRecord` and expects an unparsed response. Everything else is the
+	 * autosaves collection.
+	 *
+	 * @param {Array} autosaves The autosaves collection to serve.
+	 */
+	const mockFetch = ( autosaves ) => {
+		triggerFetch.mockImplementation( ( { path, parse } ) => {
+			if ( path.startsWith( '/wp/v2/types' ) ) {
+				const postType = {
+					slug: 'post',
+					rest_base: 'posts',
+					rest_namespace: 'wp/v2',
+					supports: { autosave: true },
+				};
+
+				if ( parse === false ) {
+					return {
+						json: async () => postType,
+						headers: { get: () => '' },
+					};
+				}
+
+				return postType;
+			}
+
+			return autosaves;
+		} );
+	};
+
+	const createTestRegistry = () => {
+		const registry = createRegistry();
+		registry.register( coreDataStore );
+		return registry;
+	};
+
+	beforeEach( () => {
+		triggerFetch.mockReset();
+	} );
+
+	/**
+	 * `hasFetchedAutosaves` reads the resolution state of `getAutosaves`, while
+	 * the editor resolves `getAutosave`. If those two ever come apart,
+	 * `isEditedPostAutosaveable` never sees a completed fetch and autosaving
+	 * silently stops working. This exercises the real resolution machinery
+	 * rather than asserting on a mocked dispatch.
+	 */
+	it( 'reports hasFetchedAutosaves once getAutosave has resolved', async () => {
+		const registry = createTestRegistry();
+		mockFetch( [ AUTOSAVE ] );
+
+		expect(
+			registry
+				.select( coreDataStore )
+				.hasFetchedAutosaves( 'post', POST_ID )
+		).toBe( false );
+
+		await registry
+			.resolveSelect( coreDataStore )
+			.getAutosave( 'post', POST_ID, AUTHOR_ID );
+
+		expect(
+			registry
+				.select( coreDataStore )
+				.hasFetchedAutosaves( 'post', POST_ID )
+		).toBe( true );
+
+		expect(
+			registry
+				.select( coreDataStore )
+				.getAutosave( 'post', POST_ID, AUTHOR_ID )
+		).toEqual( AUTOSAVE );
+	} );
+
+	it( 'reports hasFetchedAutosaves even when the author has no autosave', async () => {
+		const registry = createTestRegistry();
+		mockFetch( [] );
+
+		await registry
+			.resolveSelect( coreDataStore )
+			.getAutosave( 'post', POST_ID, AUTHOR_ID );
+
+		expect(
+			registry
+				.select( coreDataStore )
+				.hasFetchedAutosaves( 'post', POST_ID )
+		).toBe( true );
+		expect(
+			registry
+				.select( coreDataStore )
+				.getAutosave( 'post', POST_ID, AUTHOR_ID )
+		).toBeUndefined();
+	} );
+
+	it( 'requests only the given author’s autosave', async () => {
+		const registry = createTestRegistry();
+		mockFetch( [ AUTOSAVE ] );
+
+		await registry
+			.resolveSelect( coreDataStore )
+			.getAutosave( 'post', POST_ID, AUTHOR_ID );
+
+		expect( triggerFetch ).toHaveBeenCalledWith( {
+			path: `/wp/v2/posts/${ POST_ID }/autosaves?context=edit&per_page=1&author=${ AUTHOR_ID }`,
+		} );
+	} );
+
+	it( 'does not return another author’s autosave', async () => {
+		const registry = createTestRegistry();
+		mockFetch( [ { id: 100, author: 999, parent: POST_ID } ] );
+
+		await registry
+			.resolveSelect( coreDataStore )
+			.getAutosave( 'post', POST_ID, AUTHOR_ID );
+
+		expect(
+			registry
+				.select( coreDataStore )
+				.getAutosave( 'post', POST_ID, AUTHOR_ID )
+		).toBeUndefined();
+	} );
+} );

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -842,7 +842,7 @@ describe( 'getAutosaves', () => {
 		await getAutosaves( postType, postId )( { dispatch, resolveSelect } );
 
 		expect( triggerFetch ).toHaveBeenCalledWith( {
-			path: `/wp/v2/${ restBase }/${ postId }/autosaves?context=edit`,
+			path: `/wp/v2/${ restBase }/${ postId }/autosaves?context=edit&per_page=1`,
 		} );
 		expect( dispatch.receiveAutosaves ).toHaveBeenCalledWith(
 			1,
@@ -869,7 +869,7 @@ describe( 'getAutosaves', () => {
 		await getAutosaves( postType, postId )( { dispatch, resolveSelect } );
 
 		expect( triggerFetch ).toHaveBeenCalledWith( {
-			path: `/wp/v2/${ restBase }/${ postId }/autosaves?context=edit`,
+			path: `/wp/v2/${ restBase }/${ postId }/autosaves?context=edit&per_page=1`,
 		} );
 		expect( dispatch.receiveAutosaves ).not.toHaveBeenCalled();
 	} );

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -14,6 +14,7 @@ import {
 	getEmbedPreview,
 	canUser,
 	getAutosaves,
+	getAutosave,
 	getCurrentUser,
 } from '../resolvers';
 
@@ -842,7 +843,7 @@ describe( 'getAutosaves', () => {
 		await getAutosaves( postType, postId )( { dispatch, resolveSelect } );
 
 		expect( triggerFetch ).toHaveBeenCalledWith( {
-			path: `/wp/v2/${ restBase }/${ postId }/autosaves?context=edit&per_page=1`,
+			path: `/wp/v2/${ restBase }/${ postId }/autosaves?context=edit`,
 		} );
 		expect( dispatch.receiveAutosaves ).toHaveBeenCalledWith(
 			1,
@@ -869,9 +870,134 @@ describe( 'getAutosaves', () => {
 		await getAutosaves( postType, postId )( { dispatch, resolveSelect } );
 
 		expect( triggerFetch ).toHaveBeenCalledWith( {
-			path: `/wp/v2/${ restBase }/${ postId }/autosaves?context=edit&per_page=1`,
+			path: `/wp/v2/${ restBase }/${ postId }/autosaves?context=edit`,
 		} );
 		expect( dispatch.receiveAutosaves ).not.toHaveBeenCalled();
+	} );
+} );
+
+describe( 'getAutosave', () => {
+	const AUTHOR_ID = 7;
+	const SUCCESSFUL_RESPONSE = [
+		{
+			title: 'test title',
+			excerpt: 'test excerpt',
+			content: 'test content',
+			author: AUTHOR_ID,
+		},
+	];
+
+	const postType = 'post';
+	const postId = 1;
+	const restBase = 'posts';
+
+	const setUp = ( response ) => {
+		triggerFetch.mockReset();
+		triggerFetch.mockImplementation( () => response );
+
+		return {
+			dispatch: Object.assign( jest.fn(), {
+				receiveAutosaves: jest.fn(),
+				finishResolution: jest.fn(),
+			} ),
+			resolveSelect: Object.assign( jest.fn(), {
+				getPostType: jest.fn( () => ( {
+					rest_base: restBase,
+					supports: { autosave: true },
+				} ) ),
+			} ),
+		};
+	};
+
+	it( 'requests a single autosave scoped to the given author', async () => {
+		const { dispatch, resolveSelect } = setUp( SUCCESSFUL_RESPONSE );
+
+		await getAutosave(
+			postType,
+			postId,
+			AUTHOR_ID
+		)( { dispatch, resolveSelect } );
+
+		expect( triggerFetch ).toHaveBeenCalledWith( {
+			path: `/wp/v2/${ restBase }/${ postId }/autosaves?context=edit&per_page=1&author=${ AUTHOR_ID }`,
+		} );
+		expect( dispatch.receiveAutosaves ).toHaveBeenCalledWith(
+			postId,
+			SUCCESSFUL_RESPONSE
+		);
+	} );
+
+	it( 'marks getAutosaves resolution as finished so hasFetchedAutosaves reports true', async () => {
+		const { dispatch, resolveSelect } = setUp( SUCCESSFUL_RESPONSE );
+
+		await getAutosave(
+			postType,
+			postId,
+			AUTHOR_ID
+		)( { dispatch, resolveSelect } );
+
+		expect( dispatch.finishResolution ).toHaveBeenCalledWith(
+			'getAutosaves',
+			[ postType, postId ]
+		);
+	} );
+
+	it( 'finishes getAutosaves resolution even when the author has no autosave', async () => {
+		const { dispatch, resolveSelect } = setUp( [] );
+
+		await getAutosave(
+			postType,
+			postId,
+			AUTHOR_ID
+		)( { dispatch, resolveSelect } );
+
+		expect( dispatch.receiveAutosaves ).not.toHaveBeenCalled();
+		expect( dispatch.finishResolution ).toHaveBeenCalledWith(
+			'getAutosaves',
+			[ postType, postId ]
+		);
+	} );
+
+	it( 'does not fetch when the author is unknown', async () => {
+		const { dispatch, resolveSelect } = setUp( SUCCESSFUL_RESPONSE );
+
+		await getAutosave(
+			postType,
+			postId,
+			undefined
+		)( { dispatch, resolveSelect } );
+
+		expect( triggerFetch ).not.toHaveBeenCalled();
+		expect( dispatch.finishResolution ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not fetch when the post type does not support autosaves', async () => {
+		const { dispatch } = setUp( SUCCESSFUL_RESPONSE );
+		const resolveSelect = Object.assign( jest.fn(), {
+			getPostType: jest.fn( () => ( {
+				rest_base: restBase,
+				supports: { autosave: false },
+			} ) ),
+		} );
+
+		await getAutosave(
+			postType,
+			postId,
+			AUTHOR_ID
+		)( { dispatch, resolveSelect } );
+
+		expect( triggerFetch ).not.toHaveBeenCalled();
+		expect( dispatch.finishResolution ).not.toHaveBeenCalled();
+	} );
+
+	it( 'leaves the getAutosaves resolver behavior unchanged', async () => {
+		const { dispatch, resolveSelect } = setUp( SUCCESSFUL_RESPONSE );
+
+		await getAutosaves( postType, postId )( { dispatch, resolveSelect } );
+
+		expect( triggerFetch ).toHaveBeenCalledWith( {
+			path: `/wp/v2/${ restBase }/${ postId }/autosaves?context=edit`,
+		} );
 	} );
 } );
 

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -958,7 +958,7 @@ describe( 'getAutosave', () => {
 		);
 	} );
 
-	it( 'does not fetch when the author is unknown', async () => {
+	it( 'does not fetch when the author is unknown, but still finishes resolution', async () => {
 		const { dispatch, resolveSelect } = setUp( SUCCESSFUL_RESPONSE );
 
 		await getAutosave(
@@ -968,10 +968,15 @@ describe( 'getAutosave', () => {
 		)( { dispatch, resolveSelect } );
 
 		expect( triggerFetch ).not.toHaveBeenCalled();
-		expect( dispatch.finishResolution ).not.toHaveBeenCalled();
+		// Bailing without reporting would leave autosaving disabled for the
+		// session if the current user id never arrives.
+		expect( dispatch.finishResolution ).toHaveBeenCalledWith(
+			'getAutosaves',
+			[ postType, postId ]
+		);
 	} );
 
-	it( 'does not fetch when the post type does not support autosaves', async () => {
+	it( 'does not fetch when the post type does not support autosaves, but still finishes resolution', async () => {
 		const { dispatch } = setUp( SUCCESSFUL_RESPONSE );
 		const resolveSelect = Object.assign( jest.fn(), {
 			getPostType: jest.fn( () => ( {
@@ -987,7 +992,33 @@ describe( 'getAutosave', () => {
 		)( { dispatch, resolveSelect } );
 
 		expect( triggerFetch ).not.toHaveBeenCalled();
-		expect( dispatch.finishResolution ).not.toHaveBeenCalled();
+		expect( dispatch.finishResolution ).toHaveBeenCalledWith(
+			'getAutosaves',
+			[ postType, postId ]
+		);
+	} );
+
+	it( 'finishes resolution even when the request fails', async () => {
+		const { dispatch, resolveSelect } = setUp( SUCCESSFUL_RESPONSE );
+		triggerFetch.mockImplementation( () => {
+			throw new Error( 'Network error' );
+		} );
+
+		await expect(
+			getAutosave(
+				postType,
+				postId,
+				AUTHOR_ID
+			)( { dispatch, resolveSelect } )
+		).rejects.toThrow( 'Network error' );
+
+		expect( dispatch.receiveAutosaves ).not.toHaveBeenCalled();
+		// A failed fetch previously still counted as fetched, because
+		// hasFinishedResolution treats an errored resolution as complete.
+		expect( dispatch.finishResolution ).toHaveBeenCalledWith(
+			'getAutosaves',
+			[ postType, postId ]
+		);
 	} );
 
 	it( 'leaves the getAutosaves resolver behavior unchanged', async () => {


### PR DESCRIPTION
## What

Targets `adamsilverstein:fix/autosave-loading` rather than `trunk`, so it stacks on #71367.

Reworks `getAutosave` to fetch its own author-scoped record instead of narrowing `getAutosaves`, which is closer to what @Mamaduka suggested — with one wrinkle that turns out to be load-bearing.

Trac ticket: https://core.trac.wordpress.org/ticket/62057

## Why the current approach breaks autosaving

`getAutosave` currently delegates with a third argument:

```js
await resolveSelect.getAutosaves( postType, postId, 1 );
```

That records resolution under the key `[ postType, postId, 1 ]`. But `hasFetchedAutosaves` looks up a two-argument key:

```js
select( STORE_NAME ).hasFinishedResolution( 'getAutosaves', [ postType, postId ] )
```

`EquivalentKeyMap` never matches the two, so `hasFetchedAutosaves` stays `false` forever. `isEditedPostAutosaveable` in `@wordpress/editor` returns `false` while that is false, so **autosaving never enables**. There is no error and nothing in the current test suite catches it — the failure is silent.

`packages/core-data/src/test/autosaves.js` in this PR reproduces it against a real registry. Against the current branch those tests fail with `hasFetchedAutosaves` returning `false`; with this change they pass.

## The multi-author question

@Mamaduka also asked what happens when the current author did not make the latest autosave. It is a real problem, and it is the reason `per_page=1` alone is not enough.

Every consumer of `getAutosave` passes the current user's ID, and the selector filters on it:

```js
autosaves?.find( ( autosave ) => autosave.author === authorId )
```

So "the most recent autosave by anyone" is the wrong record whenever a post has more than one editor — the selector filters it out and returns `undefined`. Scoping the request by author fixes this, and it needs `author` support on the endpoint, which is being added in the companion core patch on the Trac ticket. WordPress stores exactly one autosave per author, so `per_page=1` combined with `author` is well defined.

## Changes

- `getAutosave` fetches `?context=edit&per_page=1&author=<id>` directly.
- The `getAutosaves` resolver is restored to its original behavior, so its fetch is unchanged for anyone who reaches it first. See the trade-off below for the case where `getAutosave` runs first — that one is a real behavior change.
- `getAutosave` dispatches `finishResolution( 'getAutosaves', [ postType, postId ] )` from a `finally`, so every exit path reports completion and `hasFetchedAutosaves` continues to work.
- Reverts the two test assertions expecting `per_page=1` from a two-argument `getAutosaves` call. Those currently fail on this branch — the revised resolver only appends `per_page` when the third argument is passed, so a two-argument call produces the original path.

## Trade-off worth reviewing

Reporting completion against the `getAutosaves` key also suppresses that resolver. `fulfillSelector` bails when `hasStartedResolution` is true, and that is simply "resolution state exists" — which this dispatch creates. So once `getAutosave` has run for a post, a later direct call to the `getAutosaves` selector returns the single-author array this resolver stored and never refetches the full collection.

In this repo nothing reads `state.autosaves` except `getAutosave` and `hasFetchedAutosaves`, so there is no in-tree impact. It is a genuine behavior change for third parties calling `getAutosaves` after the editor has mounted, and it is the part of this PR I would most like a second opinion on.

The alternative is changing `hasFetchedAutosaves` to observe `getAutosave` instead, which means giving it an implicit current-user dependency it does not have today. That seemed worse, but I do not feel strongly.

A related consequence: `receiveAutosaves` replaces rather than merges `state.autosaves[ postId ]`, so a single-author response overwrites a previously fetched full collection. Same reasoning — no in-tree consumer today, worth knowing.

## Why `finally`

The completion dispatch is in a `finally` rather than on the success path. The delegation it replaces completed `getAutosaves` resolution unconditionally, and `hasFinishedResolution` treats an errored resolution as complete, so a failed request still counted as fetched. Reporting only on success would leave `isEditedPostAutosaveable` false for the rest of the session after one network failure or early return — the same class of silent breakage this PR is fixing. `packages/core-data/src/test/autosaves.js` covers the failed-request and unknown-author paths.

## Ordering constraint

The `author` parameter does not exist on the endpoint yet. Until the core patch lands, this request returns the same thing it does today — WordPress ignores unknown query parameters — so nothing breaks, but the author scoping is inert.

Separately, the core-side preload path must **not** be narrowed until this change syncs into core. The preload cache is keyed on the normalized path, so a core preload of `?context=edit&per_page=1&author=N` against a client requesting `?context=edit` misses on every editor load: the preload is computed and discarded and the request goes to the network anyway. The core patch is split in two on the Trac ticket for this reason.

## Testing instructions

```
npm run test:unit packages/core-data/src/test/autosaves.js
npm run test:unit packages/core-data/src/test/resolvers.js
```

`packages/core-data/src/test/autosaves.js` is the meaningful one — it drives a real registry rather than a mocked dispatch, so it exercises `finishResolution` → `hasFinishedResolution` → `hasFetchedAutosaves` end to end.

To see the regression this fixes, revert `getAutosave` to the version on this branch and re-run `autosaves.js`: the first two tests fail with `hasFetchedAutosaves` returning `false`.

## Disclosure

This change was developed with AI assistance (Claude Code), per the [WordPress AI guidelines](https://make.wordpress.org/ai/handbook/ai-guidelines/). The commit carries a `Co-Authored-By` trailer for the same reason.

I have reviewed every line and can speak to the approach and its trade-offs — in particular the `finishResolution` call, which is the one decision here I would most like a second opinion on. The unit and integration tests above were run locally against this branch, along with the wider `packages/core-data` and `packages/editor/src/store` suites (585 tests, all passing) and ESLint.
