### PR TITLE
Media: add a review harness for grading smart crops (not for merge)

### DIFF
--- a/tools/smart-crop-corpus/README.md
+++ b/tools/smart-crop-corpus/README.md
@@ -136,3 +136,7 @@ point inherits that precision.
 -   Sources skew towards curated photography and wordpress.org assets. Neither is
     a random sample of real media libraries.
 -   Grades live in one browser's `localStorage`. Export them.
+-   Every crop is inlined, so the report grows with the run: 20 images at two
+    sizes is about 5 MB, 50 images at four sizes about 18 MB. Past roughly 40
+    images a run gets unwieldy to open and tedious to grade in one sitting.
+    Several smaller runs beat one large one.

--- a/tools/smart-crop-corpus/README.md
+++ b/tools/smart-crop-corpus/README.md
@@ -1,0 +1,138 @@
+# Smart crop review harness
+
+A scripted A/B test for the smart cropping proposal in
+[#81706](https://github.com/WordPress/gutenberg/issues/81706).
+
+It pulls a fresh mix of public images, crops each one twice with the same
+libvips build the browser upload path uses, and writes a self-contained HTML
+report where a reviewer grades whether smart crop is an improvement.
+
+**This directory is not meant to be merged.** It is a measurement tool for the
+issue discussion, kept in a branch so the numbers behind any claim about
+`attention` can be reproduced rather than asserted.
+
+## Why it exists
+
+The issue argues that `attention` should position hard-cropped sizes instead of
+the centre. That is a claim about output quality, and the thread so far has
+compared specifications rather than pictures. This makes the comparison concrete:
+run it, look at the pairs, record verdicts.
+
+## Running it
+
+Requires the repository's dependencies (`npm install`) and network access. No
+API keys.
+
+```sh
+node tools/smart-crop-corpus/index.mjs
+```
+
+```
+--count N        images to collect (default 20)
+--sizes LIST     thumbnail, square, wide, tall (default square,wide)
+--sources LIST   photos, themes, plugins (default: all three)
+--seed STRING    reproduce a previous run (default: random)
+--out DIR        output directory (default artifacts/smart-crop)
+--quality N      JPEG quality for the review renditions (default 82)
+```
+
+Every run picks a different set of images. Pass the seed printed at the top of a
+run back in with `--seed` to collect the same set again.
+
+Output lands in `artifacts/smart-crop/<date>-<seed>/`, which is already
+gitignored:
+
+| File            | For                                                           |
+| --------------- | ------------------------------------------------------------- |
+| `report.html`   | A human. Self-contained; open it directly.                    |
+| `manifest.json` | Automation. Every row, its source, and its measurements.      |
+| `images/*.jpg`  | An AI reviewer, which can read the crops as individual files. |
+
+## Grading
+
+The report is a table: one row per image per size, showing the centre crop
+(what WordPress does today) beside the attention crop.
+
+-   👍 attention keeps the subject better than centre
+-   👎 attention is worse than centre
+-   ≈ no meaningful difference
+
+Keyboard: `1` / `2` / `3` to grade and advance, `j` / `k` to move, click either
+crop to enlarge both. Grades are held in `localStorage`; "Copy results JSON"
+takes them elsewhere. Rows tagged "no visible change" are ones where attention
+picked the centre anyway and there is nothing to judge.
+
+A tally at the top reports what share of decided calls favoured smart crop.
+
+## What it crops
+
+For a standard 8-bit image, `applyResizeAndCrop()` in `packages/vips` reduces to
+a single libvips call per size:
+
+```js
+vips.Image.thumbnailBuffer( buffer, width, {
+	size: 'down',
+	height,
+	crop: smartCrop ? 'attention' : 'centre',
+} );
+```
+
+The harness makes exactly that call, against the `wasm-vips` version pinned in
+this repository, so the pixels it grades are the pixels the browser produces.
+The only difference is that it loads the module's Node entry point instead of
+the browser one; the libvips build underneath is the same.
+
+`thumbnail` is the one size WordPress core registers with `'crop' => true`, so
+it is the size this proposal actually changes. At 150px square it is also hard
+to judge by eye, so the larger theme-style shapes are the defaults and
+`thumbnail` is opt-in via `--sizes`.
+
+## Where the images come from
+
+Nothing is vendored. Each run fetches from public endpoints and records the URLs
+in the manifest, which keeps licensing with the original hosts and the
+repository small.
+
+| Source                                                       | What it contributes                                                                                                         |
+| ------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------- |
+| [Photo Directory](https://wordpress.org/photos/)             | ~43,000 CC0 photographs submitted by the community. The closest public stand-in for what people upload to WordPress.        |
+| [Theme Directory](https://wordpress.org/themes/) screenshots | Flat regions, dense text, a subject filling the frame. Nothing like a photograph.                                           |
+| [Plugin Directory](https://wordpress.org/plugins/) banners   | Logos and wordmarks on flat backgrounds — the failure class the issue calls out, where attention has nothing to latch onto. |
+
+The Photo Directory is 63% `nature` and 3.8% `people`. Sampling it
+proportionally would mostly grade landscapes, which are the case where centre
+cropping already does fine, so the harness weights towards subjects that have a
+subject to miss.
+
+## Signals
+
+libvips returns no confidence score, which the issue names as the crux of the
+proposal. It does return the attention centre, so each row records that plus the
+candidate derivations floated in the thread:
+
+-   **focal** — the attention centre, normalised. This is a real focal point from
+    libvips, not a derivation.
+-   **off-centre** — how far that point sits from the image centre. Candidate 1.
+-   **entropy agree** — agreement between the `attention` and `entropy`
+    strategies. Candidate 2, measured on their outputs rather than their crop
+    rectangles, because libvips does not expose the rectangle.
+-   **changed** — how much smart crop altered the picture at all. Near zero means
+    attention landed on the centre.
+-   **aspectStability** (manifest only) — how far the focal point moves across the
+    requested shapes. Candidate 3.
+
+Once a run is graded, these become the x-axis against a known-good/known-bad
+y-axis, which is what picking a threshold needs.
+
+One observation already worth noting: the attention centre comes back quantised
+to a coarse grid, because libvips analyses a heavily shrunk copy. A stored focal
+point inherits that precision.
+
+## Limitations
+
+-   Verdicts are not blind. A reviewer can see which column is which, so this
+    measures preference with knowledge of the condition. Randomising the columns
+    would be the next improvement if the numbers start carrying weight.
+-   Sources skew towards curated photography and wordpress.org assets. Neither is
+    a random sample of real media libraries.
+-   Grades live in one browser's `localStorage`. Export them.

--- a/tools/smart-crop-corpus/crop.mjs
+++ b/tools/smart-crop-corpus/crop.mjs
@@ -1,0 +1,272 @@
+/**
+ * Cropping for the smart crop review harness.
+ *
+ * This deliberately mirrors the production path rather than reimplementing it.
+ * For a standard 8-bit image, `applyResizeAndCrop()` in `packages/vips` ends up
+ * calling exactly one libvips operation per size:
+ *
+ *     vips.Image.thumbnailBuffer( buffer, width, {
+ *         size: 'down',
+ *         height,
+ *         crop: smartCrop ? 'attention' : 'centre',
+ *     } )
+ *
+ * so that is what this file calls, against the same pinned `wasm-vips` the
+ * browser bundle uses. The only difference is the Node entry point of the
+ * module instead of the browser one; the libvips build underneath is identical.
+ *
+ * @see packages/vips/src/index.ts
+ */
+
+// wasm-vips is a dependency of packages/vips rather than of the root package.
+// Resolving it from the workspace is the point: this harness has to crop with
+// the same pinned build the browser bundle ships.
+// eslint-disable-next-line import/no-extraneous-dependencies
+import Vips from 'wasm-vips';
+
+/**
+ * Boots libvips.
+ *
+ * @return {Promise<any>} The libvips module.
+ */
+export async function createVips() {
+	const vips = await Vips( {
+		// The optional HEIF/JXL/resvg libraries are not needed here and cost
+		// several megabytes to load.
+		dynamicLibraries: [],
+		print: () => {},
+		printErr: () => {},
+	} );
+
+	// Every image in a run is different, so the operation cache never gets a
+	// hit; all it does is hold references until the wasm heap runs out.
+	vips.Cache.max( 0 );
+
+	return vips;
+}
+
+/**
+ * Normalises an image to 3-band sRGB so two crops can be compared numerically.
+ *
+ * Takes ownership of `image` and frees it. Every libvips operation allocates a
+ * new object in a wasm heap that is not garbage collected, so anything not
+ * explicitly deleted accumulates until a run dies part way through.
+ *
+ * @param {any} image A libvips image; consumed by this call.
+ * @return {any} A new image; the caller owns it.
+ */
+function toComparable( image ) {
+	const srgb = image.colourspace( 'srgb' );
+	image.delete();
+
+	if ( ! srgb.hasAlpha() ) {
+		return srgb;
+	}
+
+	const flattened = srgb.flatten( { background: [ 255, 255, 255 ] } );
+	srgb.delete();
+	return flattened;
+}
+
+/**
+ * Mean absolute difference between two same-sized images, as a 0..1 fraction.
+ *
+ * Used as a stand-in for "did smart crop actually change anything" and for the
+ * attention/entropy agreement signal floated in the issue. It is computed on
+ * the decoded pixels, before encoding, so it is not measuring JPEG noise.
+ *
+ * @param {any} a First image.
+ * @param {any} b Second image.
+ * @return {number} 0 when identical, 1 at maximum difference.
+ */
+function meanAbsoluteDifference( a, b ) {
+	if ( a.width !== b.width || a.height !== b.height ) {
+		return 1;
+	}
+
+	const delta = a.subtract( b );
+	const difference = delta.abs();
+	delta.delete();
+
+	const mean = difference.avg();
+	difference.delete();
+
+	return mean / 255;
+}
+
+/**
+ * Largest rectangle of a given aspect ratio that fits inside the source.
+ *
+ * `smartcrop()` refuses targets larger than the input, and the focal point is a
+ * property of the aspect ratio rather than of the output pixel size, so the
+ * probe runs at whatever size actually fits.
+ *
+ * @param {number} sourceWidth  Source width.
+ * @param {number} sourceHeight Source height.
+ * @param {number} aspect       Target aspect ratio (width / height).
+ * @return {{width: number, height: number}} The fitted rectangle.
+ */
+function fitAspect( sourceWidth, sourceHeight, aspect ) {
+	// A target wider than the source is limited by the source width, and a
+	// taller one by the source height.
+	const [ width, height ] =
+		aspect >= sourceWidth / sourceHeight
+			? [ sourceWidth, sourceWidth / aspect ]
+			: [ sourceHeight * aspect, sourceHeight ];
+
+	return {
+		width: Math.max( 1, Math.min( sourceWidth, Math.floor( width ) ) ),
+		height: Math.max( 1, Math.min( sourceHeight, Math.floor( height ) ) ),
+	};
+}
+
+/**
+ * Asks libvips where the attention of an image lies, for a given aspect ratio.
+ *
+ * libvips does not return a confidence score, which the issue calls out as the
+ * crux of the proposal. It does return the attention centre, so the harness
+ * records that and derives the candidate signals from it.
+ *
+ * @param {any}    vips   The libvips module.
+ * @param {any}    source Decoded source image.
+ * @param {number} aspect Target aspect ratio (width / height).
+ * @return {{x: number, y: number}|null} Normalised focal point, or null.
+ */
+function findFocalPoint( vips, source, aspect ) {
+	const target = fitAspect( source.width, source.height, aspect );
+
+	try {
+		const options = {
+			interesting: 'attention',
+			attention_x: 0,
+			attention_y: 0,
+		};
+		// libvips writes the attention centre back onto the options object.
+		source.smartcrop( target.width, target.height, options ).delete();
+
+		return {
+			x: Number( ( options.attention_x / source.width ).toFixed( 4 ) ),
+			y: Number( ( options.attention_y / source.height ).toFixed( 4 ) ),
+		};
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Produces the centre and attention crops of one image at one target size.
+ *
+ * @param {Object} options
+ * @param {any}    options.vips    The libvips module.
+ * @param {any}    options.source  Decoded source image, for the focal point probe.
+ * @param {any}    options.buffer  Original encoded bytes.
+ * @param {Object} options.size    `{ name, width, height }`.
+ * @param {number} options.quality JPEG quality for the review renditions.
+ * @return {Object|null} Crop results, or null when the source is too small.
+ */
+export function cropPair( { vips, source, buffer, size, quality = 82 } ) {
+	// `size: 'down'` never upscales, so a source smaller than the target would
+	// silently produce something other than the requested crop.
+	if ( source.width < size.width || source.height < size.height ) {
+		return null;
+	}
+
+	const thumbnail = ( crop ) =>
+		toComparable(
+			vips.Image.thumbnailBuffer( buffer, size.width, {
+				size: 'down',
+				height: size.height,
+				crop,
+			} )
+		);
+
+	const centre = thumbnail( 'centre' );
+	const attention = thumbnail( 'attention' );
+	const entropy = thumbnail( 'entropy' );
+
+	try {
+		const changeFromCentre = meanAbsoluteDifference( attention, centre );
+		const entropyDifference = meanAbsoluteDifference( attention, entropy );
+		const focalPoint = findFocalPoint(
+			vips,
+			source,
+			size.width / size.height
+		);
+
+		return {
+			size: size.name,
+			width: size.width,
+			height: size.height,
+			renditions: {
+				centre: Buffer.from(
+					centre.writeToBuffer( '.jpg', { Q: quality } )
+				),
+				attention: Buffer.from(
+					attention.writeToBuffer( '.jpg', { Q: quality } )
+				),
+			},
+			signals: {
+				focalPoint,
+				// Candidate 1 from the issue: how far the attention centre sits
+				// from the image centre. 0 means attention agreed with centre.
+				centreOffset: focalPoint
+					? Number(
+							Math.hypot(
+								focalPoint.x - 0.5,
+								focalPoint.y - 0.5
+							).toFixed( 4 )
+					  )
+					: null,
+				// Candidate 2: agreement between the attention and entropy
+				// strategies, measured on their outputs rather than their rects,
+				// because libvips does not expose the rect.
+				entropyAgreement: Number(
+					( 1 - entropyDifference ).toFixed( 4 )
+				),
+				// How much smart crop changed the picture at all. Near zero means
+				// attention landed on the centre and there is nothing to grade.
+				changeFromCentre: Number( changeFromCentre.toFixed( 4 ) ),
+			},
+			// Below roughly half a grey level of average difference the two
+			// crops are the same picture, and asking a reviewer to compare them
+			// wastes their attention.
+			unchanged: changeFromCentre < 0.002,
+		};
+	} finally {
+		centre.delete();
+		attention.delete();
+		entropy.delete();
+	}
+}
+
+/**
+ * Spread of the focal point across the target aspect ratios.
+ *
+ * Candidate 3 from the issue: if attention picks a wildly different subject
+ * depending on the requested shape, that instability is itself a signal that
+ * the result should not be trusted.
+ *
+ * @param {Array} results Per-size results for one image.
+ * @return {number|null} Spread, or null when no focal point was found.
+ */
+export function aspectStability( results ) {
+	const points = results
+		.map( ( result ) => result.signals?.focalPoint )
+		.filter( Boolean );
+
+	if ( points.length < 2 ) {
+		return null;
+	}
+
+	const meanX =
+		points.reduce( ( sum, point ) => sum + point.x, 0 ) / points.length;
+	const meanY =
+		points.reduce( ( sum, point ) => sum + point.y, 0 ) / points.length;
+	const spread = Math.max(
+		...points.map( ( point ) =>
+			Math.hypot( point.x - meanX, point.y - meanY )
+		)
+	);
+
+	return Number( spread.toFixed( 4 ) );
+}

--- a/tools/smart-crop-corpus/index.mjs
+++ b/tools/smart-crop-corpus/index.mjs
@@ -1,0 +1,375 @@
+#!/usr/bin/env node
+/**
+ * Smart crop review harness.
+ *
+ * Pulls a fresh mix of public images, crops each one twice with the same
+ * libvips build the browser upload path uses -- from the centre, which is what
+ * WordPress does today, and with the `attention` strategy -- and writes a
+ * self-contained HTML report where a reviewer grades whether smart crop is an
+ * improvement.
+ *
+ * Usage:
+ *
+ *     node tools/smart-crop-corpus/index.mjs
+ *     node tools/smart-crop-corpus/index.mjs --count 40 --sizes thumbnail,square,wide
+ *     node tools/smart-crop-corpus/index.mjs --seed my-run   # reproducible
+ *
+ * See tools/smart-crop-corpus/README.md.
+ * See https://github.com/WordPress/gutenberg/issues/81706.
+ */
+
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { aspectStability, createVips, cropPair } from './crop.mjs';
+import { buildCorpus, download, SOURCES } from './sources.mjs';
+import { renderReport } from './report.mjs';
+
+/**
+ * Target sizes.
+ *
+ * `thumbnail` is the one size WordPress core registers with `'crop' => true`,
+ * so it is the size this proposal actually changes. It is also 150px square,
+ * which is hard to grade by eye, so the larger shapes -- the kind a theme
+ * registers -- are the defaults and `thumbnail` is opt-in.
+ */
+const SIZES = {
+	thumbnail: { name: 'thumbnail', width: 150, height: 150 },
+	square: { name: 'square', width: 400, height: 400 },
+	wide: { name: 'wide', width: 640, height: 360 },
+	tall: { name: 'tall', width: 480, height: 640 },
+};
+
+const DEFAULTS = {
+	count: 20,
+	sizes: 'square,wide',
+	sources: Object.keys( SOURCES ).join( ',' ),
+	out: 'artifacts/smart-crop',
+	quality: 82,
+	concurrency: 6,
+};
+
+/**
+ * Parses `--flag value` arguments.
+ *
+ * @param {string[]} argv Raw arguments.
+ * @return {Object} Options merged over the defaults.
+ */
+function parseArgs( argv ) {
+	const options = { ...DEFAULTS };
+
+	for ( let index = 0; index < argv.length; index += 1 ) {
+		const arg = argv[ index ];
+
+		if ( ! arg.startsWith( '--' ) ) {
+			continue;
+		}
+
+		const key = arg.slice( 2 );
+		const value = argv[ index + 1 ];
+
+		if ( key === 'help' ) {
+			options.help = true;
+		} else if ( key in options && value !== undefined ) {
+			options[ key ] =
+				typeof options[ key ] === 'number' ? Number( value ) : value;
+			index += 1;
+		} else if ( key === 'seed' && value !== undefined ) {
+			options.seed = value;
+			index += 1;
+		} else {
+			throw new Error( `Unknown option: ${ arg }` );
+		}
+	}
+
+	return options;
+}
+
+/**
+ * A small seeded generator, so a run can be reproduced from its seed.
+ *
+ * @param {string} seed Seed string.
+ * @return {Function} Generator returning 0..1.
+ */
+/* eslint-disable no-bitwise -- xmur3/mulberry32 is defined in terms of 32-bit integer operations. */
+function createRng( seed ) {
+	let hash = 1779033703 ^ seed.length;
+
+	for ( let index = 0; index < seed.length; index += 1 ) {
+		hash = Math.imul( hash ^ seed.charCodeAt( index ), 3432918353 );
+		hash = ( hash << 13 ) | ( hash >>> 19 );
+	}
+
+	return function rng() {
+		hash = ( hash + 0x6d2b79f5 ) | 0;
+		let t = Math.imul( hash ^ ( hash >>> 15 ), 1 | hash );
+		t = ( t + Math.imul( t ^ ( t >>> 7 ), 61 | t ) ) ^ t;
+		return ( ( t ^ ( t >>> 14 ) ) >>> 0 ) / 4294967296;
+	};
+}
+/* eslint-enable no-bitwise */
+
+/**
+ * Runs an async worker over a list with a concurrency cap, so the harness is a
+ * polite client of wordpress.org.
+ *
+ * @param {Array}    items  Items to process.
+ * @param {number}   limit  Maximum in flight.
+ * @param {Function} worker Async worker receiving `( item, index )`.
+ * @return {Promise<Array>} Settled results, in input order.
+ */
+async function mapLimit( items, limit, worker ) {
+	const results = new Array( items.length );
+	let cursor = 0;
+
+	async function drain() {
+		while ( cursor < items.length ) {
+			const index = cursor++;
+			try {
+				results[ index ] = await worker( items[ index ], index );
+			} catch ( error ) {
+				results[ index ] = { error };
+			}
+		}
+	}
+
+	await Promise.all(
+		Array.from( { length: Math.min( limit, items.length ) }, drain )
+	);
+
+	return results;
+}
+
+const log = ( message ) => process.stdout.write( `${ message }\n` );
+
+/**
+ * Entry point.
+ */
+async function main() {
+	const options = parseArgs( process.argv.slice( 2 ) );
+
+	if ( options.help ) {
+		log(
+			[
+				'Smart crop review harness',
+				'',
+				'  --count N        images to collect (default 20)',
+				`  --sizes LIST     any of ${ Object.keys( SIZES ).join(
+					', '
+				) } (default ${ DEFAULTS.sizes })`,
+				`  --sources LIST   any of ${ Object.keys( SOURCES ).join(
+					', '
+				) }`,
+				'  --seed STRING    reproduce a previous run (default: random)',
+				'  --out DIR        output directory (default artifacts/smart-crop)',
+				'  --quality N      JPEG quality for review renditions (default 82)',
+			].join( '\n' )
+		);
+		return;
+	}
+
+	// A random seed by default, so every run grades a different set of images.
+	const seed = options.seed || Math.random().toString( 36 ).slice( 2, 10 );
+	const rng = createRng( seed );
+
+	const sizes = String( options.sizes )
+		.split( ',' )
+		.map( ( key ) => SIZES[ key.trim() ] )
+		.filter( Boolean );
+
+	if ( ! sizes.length ) {
+		throw new Error(
+			`No valid sizes. Choose from: ${ Object.keys( SIZES ).join(
+				', '
+			) }`
+		);
+	}
+
+	const runId = `${ new Date().toISOString().slice( 0, 10 ) }-${ seed }`;
+	const outDir = path.resolve( options.out, runId );
+	const imageDir = path.join( outDir, 'images' );
+	await mkdir( imageDir, { recursive: true } );
+
+	log( `Smart crop review run ${ runId }` );
+	log( `Seed ${ seed } — pass --seed ${ seed } to reproduce this set.\n` );
+
+	const corpus = await buildCorpus( {
+		count: options.count,
+		sources: String( options.sources )
+			.split( ',' )
+			.map( ( key ) => key.trim() ),
+		rng,
+		onLog: log,
+	} );
+
+	if ( ! corpus.length ) {
+		throw new Error( 'Collected no images. Is the network reachable?' );
+	}
+
+	log( `\nDownloading ${ corpus.length } images…` );
+
+	const downloaded = await mapLimit(
+		corpus,
+		options.concurrency,
+		async ( entry ) => ( { entry, buffer: await download( entry.url ) } )
+	);
+
+	const vips = await createVips();
+	const vipsVersion = [ 0, 1, 2 ]
+		.map( ( part ) => vips.version( part ) )
+		.join( '.' );
+
+	log( `Cropping with libvips ${ vipsVersion }…\n` );
+
+	const rows = [];
+	const stats = { bySource: {}, unchanged: 0, imageCount: 0, skipped: 0 };
+
+	for ( const item of downloaded ) {
+		if ( item.error || ! item.buffer ) {
+			stats.skipped += 1;
+			continue;
+		}
+
+		const { entry, buffer } = item;
+		let source;
+
+		try {
+			// The decoded image is freed straight away; only the sRGB copy is
+			// kept, and the wasm heap does not reclaim anything on its own.
+			const decoded = vips.Image.newFromBuffer( buffer );
+			source = decoded.colourspace( 'srgb' );
+			decoded.delete();
+		} catch {
+			log( `  ! could not decode ${ entry.id }` );
+			stats.skipped += 1;
+			continue;
+		}
+
+		try {
+			const results = sizes
+				.map( ( size ) =>
+					cropPair( {
+						vips,
+						source,
+						buffer,
+						size,
+						quality: options.quality,
+					} )
+				)
+				.filter( Boolean );
+
+			if ( ! results.length ) {
+				log( `  - ${ entry.id } is smaller than every target size` );
+				stats.skipped += 1;
+				continue;
+			}
+
+			// A small preview of the uncropped original, so a reviewer can see
+			// what the crops were taken from.
+			const previewImage = vips.Image.thumbnailBuffer( buffer, 220, {
+				size: 'down',
+			} );
+			const preview = Buffer.from(
+				previewImage.writeToBuffer( '.jpg', { Q: 70 } )
+			);
+			previewImage.delete();
+
+			const image = {
+				...entry,
+				preview,
+				width: entry.width || source.width,
+				height: entry.height || source.height,
+			};
+			const stability = aspectStability( results );
+
+			await writeFile(
+				path.join( imageDir, `${ entry.id }-source.jpg` ),
+				preview
+			);
+
+			for ( const result of results ) {
+				const rowId = `${ entry.id }-${ result.size }`;
+				const files = {
+					centre: `images/${ rowId }-centre.jpg`,
+					attention: `images/${ rowId }-attention.jpg`,
+					source: `images/${ entry.id }-source.jpg`,
+				};
+
+				await writeFile(
+					path.join( outDir, files.centre ),
+					result.renditions.centre
+				);
+				await writeFile(
+					path.join( outDir, files.attention ),
+					result.renditions.attention
+				);
+
+				rows.push( {
+					id: rowId,
+					image,
+					result,
+					files,
+					aspectStability: stability,
+				} );
+
+				if ( result.unchanged ) {
+					stats.unchanged += 1;
+				}
+			}
+
+			stats.imageCount += 1;
+			stats.bySource[ entry.source ] =
+				( stats.bySource[ entry.source ] || 0 ) + 1;
+		} finally {
+			source.delete();
+		}
+	}
+
+	if ( ! rows.length ) {
+		throw new Error( 'No comparisons were produced.' );
+	}
+
+	const run = {
+		id: runId,
+		seed,
+		createdAt: new Date().toISOString(),
+		vipsVersion,
+		sizes: sizes.map( ( size ) => size.name ),
+		rows,
+		stats,
+	};
+
+	const reportPath = path.join( outDir, 'report.html' );
+	await writeFile( reportPath, renderReport( run ) );
+	await writeFile(
+		path.join( outDir, 'manifest.json' ),
+		JSON.stringify(
+			{
+				...run,
+				rows: rows.map( ( row ) => ( {
+					id: row.id,
+					image: { ...row.image, preview: undefined },
+					size: row.result.size,
+					signals: row.result.signals,
+					aspectStability: row.aspectStability,
+					unchanged: row.result.unchanged,
+					files: row.files,
+				} ) ),
+			},
+			null,
+			2
+		)
+	);
+
+	log( `${ rows.length } comparisons from ${ stats.imageCount } images` );
+	log(
+		`${ stats.unchanged } produced no visible change; ${ stats.skipped } images skipped`
+	);
+	log( `\nReport:   ${ reportPath }` );
+	log( `Manifest: ${ path.join( outDir, 'manifest.json' ) }` );
+}
+
+main().catch( ( error ) => {
+	process.stderr.write( `\n${ error.stack || error.message }\n` );
+	process.exitCode = 1;
+} );

--- a/tools/smart-crop-corpus/report.mjs
+++ b/tools/smart-crop-corpus/report.mjs
@@ -1,0 +1,517 @@
+/**
+ * Review artifact for the smart crop harness.
+ *
+ * Produces one self-contained HTML file: every image is inlined, so the report
+ * can be opened from disk, mailed around, or published without dragging a
+ * directory of assets behind it.
+ *
+ * The same data is emitted twice on purpose. The table is for a human with a
+ * mouse; the `application/json` block at the end of the document carries the
+ * identical rows in machine-readable form so an AI reviewer can grade the run
+ * by reading the file and the numbered crop files beside it.
+ */
+
+/**
+ * Escapes text for interpolation into HTML.
+ *
+ * @param {any} value Value to escape.
+ * @return {string} Escaped text.
+ */
+function escapeHtml( value ) {
+	return String( value ?? '' ).replace(
+		/[&<>"']/g,
+		( character ) =>
+			( {
+				'&': '&amp;',
+				'<': '&lt;',
+				'>': '&gt;',
+				'"': '&quot;',
+				"'": '&#39;',
+			} )[ character ]
+	);
+}
+
+/**
+ * Inlines an image buffer as a data URI.
+ *
+ * @param {Buffer} buffer Image bytes.
+ * @return {string} A `data:` URI.
+ */
+function dataUri( buffer ) {
+	return `data:image/jpeg;base64,${ buffer.toString( 'base64' ) }`;
+}
+
+const STYLES = `
+:root {
+	color-scheme: light dark;
+	--bg: #ffffff;
+	--surface: #f6f7f7;
+	--surface-2: #ffffff;
+	--border: #dcdcde;
+	--text: #1e1e1e;
+	--muted: #646970;
+	--accent: #3858e9;
+	--good: #007017;
+	--good-bg: #edfaef;
+	--bad: #8a2424;
+	--bad-bg: #fcf0f1;
+	--shadow: 0 1px 3px rgba( 0, 0, 0, 0.08 );
+}
+:root:not([data-theme="light"]) {
+	--bg: #101517;
+	--surface: #1a2023;
+	--surface-2: #141a1c;
+	--border: #2f3739;
+	--text: #e8eaea;
+	--muted: #9ba3a6;
+	--accent: #8ba3ff;
+	--good: #7ddc90;
+	--good-bg: #14301b;
+	--bad: #ff9d9d;
+	--bad-bg: #351718;
+	--shadow: 0 1px 3px rgba( 0, 0, 0, 0.4 );
+}
+@media ( prefers-color-scheme: light ) {
+	:root:not([data-theme="dark"]) {
+		--bg: #ffffff;
+		--surface: #f6f7f7;
+		--surface-2: #ffffff;
+		--border: #dcdcde;
+		--text: #1e1e1e;
+		--muted: #646970;
+		--accent: #3858e9;
+		--good: #007017;
+		--good-bg: #edfaef;
+		--bad: #8a2424;
+		--bad-bg: #fcf0f1;
+		--shadow: 0 1px 3px rgba( 0, 0, 0, 0.08 );
+	}
+}
+* { box-sizing: border-box; }
+body {
+	margin: 0;
+	padding: 0 0 6rem;
+	background: var( --bg );
+	color: var( --text );
+	font: 15px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+}
+.wrap { max-width: 1240px; margin: 0 auto; padding: 0 1.25rem; }
+header { padding: 2.5rem 0 1.25rem; }
+h1 { font-size: 1.6rem; margin: 0 0 0.35rem; letter-spacing: -0.01em; }
+.lede { color: var( --muted ); margin: 0 0 1.25rem; max-width: 62ch; }
+.meta {
+	display: flex; flex-wrap: wrap; gap: 0.4rem 0.5rem;
+	font-size: 0.8rem; color: var( --muted );
+}
+.meta span {
+	background: var( --surface ); border: 1px solid var( --border );
+	border-radius: 999px; padding: 0.15rem 0.65rem;
+}
+.bar {
+	position: sticky; top: 0; z-index: 20;
+	background: var( --bg ); border-bottom: 1px solid var( --border );
+	padding: 0.7rem 0; margin-bottom: 1.25rem;
+}
+.bar-inner {
+	max-width: 1240px; margin: 0 auto; padding: 0 1.25rem;
+	display: flex; align-items: center; gap: 0.75rem; flex-wrap: wrap;
+}
+.tally { font-variant-numeric: tabular-nums; font-size: 0.9rem; }
+.tally b { font-size: 1.05rem; }
+.grow { flex: 1 1 auto; }
+button {
+	font: inherit; cursor: pointer; border-radius: 4px;
+	border: 1px solid var( --border ); background: var( --surface-2 );
+	color: var( --text ); padding: 0.35rem 0.7rem;
+}
+button:hover { border-color: var( --accent ); }
+.tblwrap { overflow-x: auto; border: 1px solid var( --border ); border-radius: 6px; }
+table { border-collapse: collapse; width: 100%; min-width: 900px; background: var( --surface-2 ); }
+th {
+	text-align: left; font-size: 0.72rem; text-transform: uppercase;
+	letter-spacing: 0.05em; color: var( --muted ); font-weight: 600;
+	padding: 0.6rem 0.75rem; border-bottom: 1px solid var( --border );
+	background: var( --surface );
+}
+td { padding: 0.75rem; border-bottom: 1px solid var( --border ); vertical-align: top; }
+tr[data-verdict="up"] { background: var( --good-bg ); }
+tr[data-verdict="down"] { background: var( --bad-bg ); }
+tr.focused td:first-child { box-shadow: inset 3px 0 0 var( --accent ); }
+.idx { font-variant-numeric: tabular-nums; color: var( --muted ); font-size: 0.8rem; }
+.src { min-width: 190px; max-width: 230px; }
+.src img { width: 100%; border-radius: 3px; display: block; margin-bottom: 0.4rem; }
+.src .title { font-weight: 600; font-size: 0.85rem; word-break: break-word; }
+.src .attr { font-size: 0.74rem; color: var( --muted ); }
+.src a { color: var( --accent ); }
+.crop { text-align: center; }
+.crop img {
+	max-width: 260px; width: 100%; height: auto; cursor: zoom-in;
+	border-radius: 3px; box-shadow: var( --shadow ); display: block; margin: 0 auto;
+}
+.crop .cap { font-size: 0.72rem; color: var( --muted ); margin-top: 0.35rem; }
+.sig { font-size: 0.74rem; color: var( --muted ); min-width: 150px; line-height: 1.5; }
+.sig code { color: var( --text ); font-size: 0.72rem; }
+.vote { white-space: nowrap; min-width: 130px; }
+.vote button { font-size: 1.05rem; padding: 0.3rem 0.6rem; margin: 0 0.15rem 0.3rem 0; }
+.vote button[aria-pressed="true"] { border-color: var( --accent ); background: var( --accent ); color: #fff; }
+.vote .hint { display: block; font-size: 0.7rem; color: var( --muted ); }
+.pill {
+	display: inline-block; font-size: 0.68rem; padding: 0.05rem 0.4rem;
+	border: 1px solid var( --border ); border-radius: 999px; color: var( --muted );
+}
+details { margin: 1.5rem 0; }
+summary { cursor: pointer; color: var( --muted ); font-size: 0.85rem; }
+pre {
+	background: var( --surface ); border: 1px solid var( --border );
+	border-radius: 4px; padding: 0.85rem; overflow-x: auto;
+	font-size: 0.75rem; max-height: 22rem;
+}
+#lightbox {
+	position: fixed; inset: 0; z-index: 100; display: none;
+	background: rgba( 0, 0, 0, 0.85 ); padding: 2rem; overflow: auto;
+	align-items: center; justify-content: center; gap: 1.5rem; flex-wrap: wrap;
+}
+#lightbox.open { display: flex; }
+#lightbox figure { margin: 0; text-align: center; }
+#lightbox img { max-width: 46vw; max-height: 82vh; border-radius: 4px; }
+#lightbox figcaption { color: #fff; font-size: 0.8rem; margin-top: 0.5rem; }
+@media ( max-width: 900px ) { #lightbox img { max-width: 88vw; max-height: 44vh; } }
+`;
+
+const SCRIPT = `
+( function () {
+	var runId = document.body.dataset.runId;
+	var key = 'smart-crop-verdicts:' + runId;
+	var verdicts = {};
+
+	try {
+		verdicts = JSON.parse( localStorage.getItem( key ) || '{}' );
+	} catch ( e ) {}
+
+	var rows = Array.prototype.slice.call(
+		document.querySelectorAll( 'tr[data-row-id]' )
+	);
+	var focused = 0;
+
+	function save() {
+		try {
+			localStorage.setItem( key, JSON.stringify( verdicts ) );
+		} catch ( e ) {}
+	}
+
+	function render() {
+		var up = 0, down = 0, same = 0;
+
+		rows.forEach( function ( row ) {
+			var id = row.dataset.rowId;
+			var verdict = verdicts[ id ] || '';
+
+			if ( verdict === 'up' ) { up++; }
+			if ( verdict === 'down' ) { down++; }
+			if ( verdict === 'same' ) { same++; }
+
+			row.dataset.verdict = verdict;
+			row.querySelectorAll( '.vote button' ).forEach( function ( button ) {
+				button.setAttribute(
+					'aria-pressed',
+					button.dataset.verdict === verdict ? 'true' : 'false'
+				);
+			} );
+		} );
+
+		var graded = up + down + same;
+		var decided = up + down;
+		document.getElementById( 'tally' ).innerHTML =
+			'<b>' + up + '</b> better &middot; <b>' + down + '</b> worse &middot; <b>' +
+			same + '</b> no difference &middot; ' + ( rows.length - graded ) + ' left' +
+			( decided ? ' &middot; <b>' + Math.round( ( up / decided ) * 100 ) +
+			'%</b> of decided calls favour smart crop' : '' );
+	}
+
+	function focus( index ) {
+		if ( index < 0 || index >= rows.length ) { return; }
+		rows[ focused ].classList.remove( 'focused' );
+		focused = index;
+		rows[ focused ].classList.add( 'focused' );
+		rows[ focused ].scrollIntoView( { block: 'center', behavior: 'smooth' } );
+	}
+
+	document.addEventListener( 'click', function ( event ) {
+		var button = event.target.closest( '.vote button' );
+
+		if ( button ) {
+			var row = button.closest( 'tr' );
+			var id = row.dataset.rowId;
+			verdicts[ id ] = verdicts[ id ] === button.dataset.verdict
+				? ''
+				: button.dataset.verdict;
+			focused = rows.indexOf( row );
+			save();
+			render();
+			return;
+		}
+
+		var zoom = event.target.closest( '.crop img' );
+
+		if ( zoom ) {
+			var cells = zoom.closest( 'tr' ).querySelectorAll( '.crop img' );
+			document.getElementById( 'lb-a' ).src = cells[ 0 ].src;
+			document.getElementById( 'lb-b' ).src = cells[ 1 ].src;
+			document.getElementById( 'lightbox' ).classList.add( 'open' );
+		}
+	} );
+
+	document.getElementById( 'lightbox' ).addEventListener( 'click', function () {
+		this.classList.remove( 'open' );
+	} );
+
+	document.addEventListener( 'keydown', function ( event ) {
+		if ( event.metaKey || event.ctrlKey || event.altKey ) { return; }
+
+		if ( event.key === 'Escape' ) {
+			document.getElementById( 'lightbox' ).classList.remove( 'open' );
+			return;
+		}
+
+		var map = { '1': 'up', '2': 'down', '3': 'same' };
+
+		if ( map[ event.key ] ) {
+			var id = rows[ focused ].dataset.rowId;
+			verdicts[ id ] = verdicts[ id ] === map[ event.key ] ? '' : map[ event.key ];
+			save();
+			render();
+			focus( focused + 1 );
+		} else if ( event.key === 'j' ) {
+			focus( focused + 1 );
+		} else if ( event.key === 'k' ) {
+			focus( focused - 1 );
+		}
+	} );
+
+	document.getElementById( 'copy' ).addEventListener( 'click', function () {
+		var payload = JSON.stringify( {
+			runId: runId,
+			gradedAt: new Date().toISOString(),
+			verdicts: verdicts,
+		}, null, 2 );
+		var output = document.getElementById( 'results' );
+		output.textContent = payload;
+		output.closest( 'details' ).open = true;
+
+		if ( navigator.clipboard ) {
+			navigator.clipboard.writeText( payload ).then( function () {
+				document.getElementById( 'copy' ).textContent = 'Copied';
+			}, function () {} );
+		}
+	} );
+
+	document.getElementById( 'reset' ).addEventListener( 'click', function () {
+		verdicts = {};
+		save();
+		render();
+	} );
+
+	rows[ 0 ] && rows[ 0 ].classList.add( 'focused' );
+	render();
+} )();
+`;
+
+/**
+ * Renders one comparison row.
+ *
+ * @param {Object} row   Row data.
+ * @param {number} index Row number.
+ * @return {string} HTML.
+ */
+function renderRow( row, index ) {
+	const { image, result } = row;
+	const signals = result.signals;
+	const focal = signals.focalPoint;
+
+	return `
+		<tr data-row-id="${ escapeHtml( row.id ) }" data-verdict="">
+			<td class="idx">${ index + 1 }</td>
+			<td class="src">
+				<img src="${ dataUri( image.preview ) }" alt="Source image: ${ escapeHtml(
+					image.title
+				) }" loading="lazy">
+				<div class="title">${ escapeHtml( image.title ) }</div>
+				<div class="attr">
+					${ escapeHtml( image.source ) }<br>
+					${ escapeHtml( image.license ) }<br>
+					<span class="pill">${ escapeHtml( image.subject ) }</span>
+					${
+						image.pageUrl
+							? `<a href="${ escapeHtml(
+									image.pageUrl
+							  ) }" target="_blank" rel="noreferrer">source</a>`
+							: ''
+					}
+				</div>
+			</td>
+			<td class="idx">${ escapeHtml( result.size ) }<br>
+				<span class="attr">${ result.width }&times;${ result.height }</span>
+			</td>
+			<td class="crop">
+				<img src="${ dataUri(
+					result.renditions.centre
+				) }" alt="Centre crop" loading="lazy">
+				<div class="cap">Centre &mdash; today</div>
+			</td>
+			<td class="crop">
+				<img src="${ dataUri(
+					result.renditions.attention
+				) }" alt="Attention crop" loading="lazy">
+				<div class="cap">Attention &mdash; smart crop</div>
+			</td>
+			<td class="sig">
+				${
+					focal
+						? `focal <code>${ focal.x }, ${ focal.y }</code><br>`
+						: 'focal <code>n/a</code><br>'
+				}
+				off-centre <code>${ signals.centreOffset ?? 'n/a' }</code><br>
+				entropy agree <code>${ signals.entropyAgreement }</code><br>
+				changed <code>${ signals.changeFromCentre }</code>
+				${ result.unchanged ? '<br><span class="pill">no visible change</span>' : '' }
+			</td>
+			<td class="vote">
+				<button data-verdict="up" aria-pressed="false" title="Smart crop is better (1)">&#128077;</button>
+				<button data-verdict="down" aria-pressed="false" title="Smart crop is worse (2)">&#128078;</button>
+				<button data-verdict="same" aria-pressed="false" title="No meaningful difference (3)">&asymp;</button>
+				<span class="hint">1 / 2 / 3</span>
+			</td>
+		</tr>`;
+}
+
+/**
+ * Builds the review report.
+ *
+ * @param {Object} run Run data: `{ id, seed, createdAt, vipsVersion, sizes, rows, stats }`.
+ * @return {string} A complete HTML document.
+ */
+export function renderReport( run ) {
+	const rows = run.rows.map( renderRow ).join( '' );
+
+	const manifest = {
+		runId: run.id,
+		seed: run.seed,
+		createdAt: run.createdAt,
+		vipsVersion: run.vipsVersion,
+		sizes: run.sizes,
+		howToGrade:
+			'For each row, compare the centre crop (current WordPress behaviour) ' +
+			'with the attention crop (libvips smart crop). Record "up" when the ' +
+			'attention crop keeps the subject better, "down" when it is worse than ' +
+			'centre, and "same" when there is no meaningful difference.',
+		rows: run.rows.map( ( row ) => ( {
+			id: row.id,
+			image: {
+				id: row.image.id,
+				title: row.image.title,
+				source: row.image.source,
+				subject: row.image.subject,
+				license: row.image.license,
+				url: row.image.url,
+				pageUrl: row.image.pageUrl,
+				width: row.image.width,
+				height: row.image.height,
+			},
+			size: row.result.size,
+			width: row.result.width,
+			height: row.result.height,
+			signals: row.result.signals,
+			aspectStability: row.aspectStability,
+			unchanged: row.result.unchanged,
+			files: row.files,
+		} ) ),
+	};
+
+	return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Smart Crop Review</title>
+<style>${ STYLES }</style>
+</head>
+<body data-run-id="${ escapeHtml( run.id ) }">
+<div class="wrap">
+	<header>
+		<h1>Smart crop review</h1>
+		<p class="lede">
+			Each row is one image at one hard-cropped size, cropped twice by the same
+			libvips build the browser upload path uses: once from the centre, which is
+			what WordPress does today, and once with the <code>attention</code>
+			strategy. Grade whether attention is an improvement. Rows marked
+			&ldquo;no visible change&rdquo; are ones where attention chose the centre
+			anyway.
+		</p>
+		<div class="meta">
+			<span>${ run.rows.length } comparisons</span>
+			<span>${ run.stats.imageCount } images</span>
+			<span>seed ${ escapeHtml( run.seed ) }</span>
+			<span>libvips ${ escapeHtml( run.vipsVersion ) }</span>
+			<span>${ escapeHtml( run.createdAt ) }</span>
+			${ Object.entries( run.stats.bySource )
+				.map(
+					( [ name, count ] ) =>
+						`<span>${ escapeHtml( name ) }: ${ count }</span>`
+				)
+				.join( '' ) }
+			<span>${ run.stats.unchanged } unchanged</span>
+		</div>
+	</header>
+</div>
+
+<div class="bar">
+	<div class="bar-inner">
+		<span class="tally" id="tally"></span>
+		<span class="grow"></span>
+		<button id="copy">Copy results JSON</button>
+		<button id="reset">Reset grades</button>
+	</div>
+</div>
+
+<div class="wrap">
+	<div class="tblwrap">
+		<table>
+			<thead>
+				<tr>
+					<th>#</th>
+					<th>Source</th>
+					<th>Size</th>
+					<th>Centre</th>
+					<th>Attention</th>
+					<th>Signals</th>
+					<th>Verdict</th>
+				</tr>
+			</thead>
+			<tbody>${ rows }</tbody>
+		</table>
+	</div>
+
+	<details>
+		<summary>Results JSON &mdash; grades are kept in this browser; use &ldquo;Copy results JSON&rdquo; to take them elsewhere</summary>
+		<pre id="results">No grades recorded yet.</pre>
+	</details>
+
+	<details>
+		<summary>Run manifest &mdash; the same rows in machine-readable form, for an AI reviewer</summary>
+		<pre>${ escapeHtml( JSON.stringify( manifest, null, 2 ) ) }</pre>
+	</details>
+</div>
+
+<div id="lightbox">
+	<figure><img id="lb-a" alt="Centre crop, enlarged"><figcaption>Centre &mdash; today</figcaption></figure>
+	<figure><img id="lb-b" alt="Attention crop, enlarged"><figcaption>Attention &mdash; smart crop</figcaption></figure>
+</div>
+
+<script type="application/json" id="run-data">${ JSON.stringify(
+		manifest
+	).replace( /</g, '\\u003c' ) }</script>
+<script>${ SCRIPT }</script>
+</body>
+</html>
+`;
+}

--- a/tools/smart-crop-corpus/sources.mjs
+++ b/tools/smart-crop-corpus/sources.mjs
@@ -1,0 +1,359 @@
+/**
+ * Corpus sources for the smart crop review harness.
+ *
+ * Every source is public, needs no authentication, and is fetched fresh on each
+ * run so that a review never grades the same pictures twice. Nothing is checked
+ * into the repository: a run produces a manifest of URLs plus the images it
+ * downloaded, which keeps the licensing question where it belongs (with the
+ * original hosts) and keeps the repository small.
+ *
+ * See https://github.com/WordPress/gutenberg/issues/81706 for the discussion of
+ * what a representative corpus needs to contain.
+ */
+
+const USER_AGENT =
+	'gutenberg-smart-crop-corpus (https://github.com/WordPress/gutenberg/issues/81706)';
+
+/**
+ * Categories in the Photo Directory, weighted towards the subjects where a
+ * centre crop is most likely to be wrong.
+ *
+ * The directory itself is 63% `nature` and only 3.8% `people`. Sampling it
+ * proportionally would mostly grade landscapes, which are the case where centre
+ * cropping already does fine. These weights deliberately oversample subjects
+ * that have a subject to miss.
+ */
+const PHOTO_CATEGORY_WEIGHTS = {
+	people: 5,
+	animals: 4,
+	'food-drink': 3,
+	objects: 3,
+	fashion: 2,
+	athletics: 2,
+	'arts-culture': 2,
+	transportation: 2,
+	architecture: 1,
+	interiors: 1,
+	technology: 1,
+	nature: 1,
+	patterns: 1,
+};
+
+/**
+ * Fetches JSON with a descriptive user agent and a useful error on failure.
+ *
+ * @param {string} url       URL to fetch.
+ * @param {Object} [options] Fetch options.
+ * @return {Promise<any>} Parsed JSON body.
+ */
+async function fetchJson( url, options = {} ) {
+	const response = await fetch( url, {
+		...options,
+		headers: { 'user-agent': USER_AGENT, ...options.headers },
+	} );
+
+	if ( ! response.ok ) {
+		throw new Error(
+			`Request failed (${ response.status } ${ response.statusText }): ${ url }`
+		);
+	}
+
+	return {
+		body: await response.json(),
+		total: Number( response.headers.get( 'x-wp-total' ) ) || undefined,
+	};
+}
+
+/**
+ * Picks `count` items at random from a list, without replacement.
+ *
+ * @param {Array}    items List to sample from.
+ * @param {number}   count How many to take.
+ * @param {Function} rng   Random number generator returning 0..1.
+ * @return {Array} The sample.
+ */
+function sample( items, count, rng ) {
+	const pool = [ ...items ];
+	const picked = [];
+
+	while ( picked.length < count && pool.length > 0 ) {
+		picked.push( pool.splice( Math.floor( rng() * pool.length ), 1 )[ 0 ] );
+	}
+
+	return picked;
+}
+
+/**
+ * Picks a weighted-random key from a `{ key: weight }` map.
+ *
+ * @param {Object}   weights Map of key to relative weight.
+ * @param {Function} rng     Random number generator returning 0..1.
+ * @return {string} The chosen key.
+ */
+function weightedPick( weights, rng ) {
+	const entries = Object.entries( weights );
+	const total = entries.reduce( ( sum, [ , weight ] ) => sum + weight, 0 );
+	let target = rng() * total;
+
+	for ( const [ key, weight ] of entries ) {
+		target -= weight;
+		if ( target <= 0 ) {
+			return key;
+		}
+	}
+
+	return entries[ entries.length - 1 ][ 0 ];
+}
+
+/**
+ * WordPress Photo Directory: 43,000+ CC0 photographs submitted by the community.
+ *
+ * This is the closest public stand-in for "what people upload to WordPress",
+ * and CC0 means there is no attribution burden on the harness.
+ *
+ * @param {number}   count Number of images to collect.
+ * @param {Function} rng   Random number generator returning 0..1.
+ * @return {Promise<Array>} Corpus entries.
+ */
+async function fromPhotoDirectory( count, rng ) {
+	const base = 'https://wordpress.org/photos/wp-json/wp/v2';
+
+	const { body: categories } = await fetchJson(
+		`${ base }/photo-categories?per_page=100&_fields=id,slug,count`
+	);
+	const bySlug = Object.fromEntries(
+		categories.map( ( term ) => [ term.slug, term ] )
+	);
+
+	const entries = [];
+	const seen = new Set();
+	let attempts = 0;
+
+	// Each pass picks one weighted-random category and a random offset within
+	// it, so consecutive runs land in completely different parts of the archive.
+	while ( entries.length < count && attempts < count * 4 ) {
+		attempts++;
+
+		const slug = weightedPick( PHOTO_CATEGORY_WEIGHTS, rng );
+		const term = bySlug[ slug ];
+		if ( ! term || ! term.count ) {
+			continue;
+		}
+
+		const perPage = 20;
+		const offset = Math.floor(
+			rng() * Math.max( 1, term.count - perPage )
+		);
+		const { body: photos } = await fetchJson(
+			`${ base }/photos?per_page=${ perPage }&offset=${ offset }` +
+				`&photo-categories=${ term.id }&_embed=wp:featuredmedia`
+		);
+
+		for ( const photo of sample( photos, 3, rng ) ) {
+			if ( entries.length >= count ) {
+				break;
+			}
+
+			const media = photo._embedded?.[ 'wp:featuredmedia' ]?.[ 0 ];
+			const details = media?.media_details;
+			if ( ! media?.source_url || ! details?.width ) {
+				continue;
+			}
+
+			// Prefer a large-but-not-enormous rendition. Originals run to 4000px
+			// and 4MB, which slows a run down without changing what attention
+			// picks. Anything at this size is still a realistic upload.
+			const rendition =
+				details.sizes?.[ '1536x1536' ] ||
+				details.sizes?.[ '2048x2048' ] ||
+				details.sizes?.large;
+
+			const url = rendition?.source_url || media.source_url;
+			if ( seen.has( url ) ) {
+				continue;
+			}
+			seen.add( url );
+
+			entries.push( {
+				id: `photo-${ photo.id }`,
+				url,
+				title: photo.title?.rendered?.trim() || `Photo ${ photo.id }`,
+				pageUrl: photo.link,
+				credit: media.author_name || 'WordPress Photo Directory',
+				license: 'CC0',
+				source: 'WordPress Photo Directory',
+				subject: slug,
+				width: rendition?.width || details.width,
+				height: rendition?.height || details.height,
+			} );
+		}
+	}
+
+	return entries;
+}
+
+/**
+ * Theme directory screenshots.
+ *
+ * Screenshots are a common real-world upload and behave nothing like a
+ * photograph: flat regions, dense text, and a subject that fills the frame.
+ *
+ * @param {number}   count Number of images to collect.
+ * @param {Function} rng   Random number generator returning 0..1.
+ * @return {Promise<Array>} Corpus entries.
+ */
+async function fromThemeScreenshots( count, rng ) {
+	const perPage = 40;
+	const page = 1 + Math.floor( rng() * 30 );
+	const url =
+		'https://api.wordpress.org/themes/info/1.2/?action=query_themes' +
+		`&request[per_page]=${ perPage }&request[page]=${ page }` +
+		'&request[browse]=popular';
+
+	const { body } = await fetchJson( url );
+
+	return sample( body.themes || [], count, rng )
+		.filter( ( theme ) => theme.screenshot_url )
+		.map( ( theme ) => ( {
+			id: `theme-${ theme.slug }`,
+			// The API returns protocol-relative URLs.
+			url: theme.screenshot_url.replace( /^\/\//, 'https://' ),
+			title: `${ theme.name } (theme screenshot)`,
+			pageUrl: `https://wordpress.org/themes/${ theme.slug }/`,
+			credit: theme.author?.display_name || theme.author?.user_nicename,
+			license: 'GPL-compatible (theme directory requirement)',
+			source: 'WordPress Theme Directory',
+			subject: 'screenshot',
+		} ) );
+}
+
+/**
+ * Plugin directory banners.
+ *
+ * A 1544x500 banner is usually a logo or wordmark on a flat background, which
+ * is the failure class called out in the issue: attention scoring has nothing
+ * to latch onto, and a confidence signal needs to notice that.
+ *
+ * @param {number}   count Number of images to collect.
+ * @param {Function} rng   Random number generator returning 0..1.
+ * @return {Promise<Array>} Corpus entries.
+ */
+async function fromPluginBanners( count, rng ) {
+	const perPage = 40;
+	const page = 1 + Math.floor( rng() * 60 );
+	const url =
+		'https://api.wordpress.org/plugins/info/1.2/?action=query_plugins' +
+		`&request[per_page]=${ perPage }&request[page]=${ page }` +
+		'&request[fields][banners]=1';
+
+	const { body } = await fetchJson( url );
+
+	return sample( body.plugins || [], count * 2, rng )
+		.map( ( plugin ) => {
+			// Only the 1544x500 banner is large enough to crop against the
+			// target sizes; the 772x250 fallback is shorter than most of them.
+			// The API returns `false` rather than omitting a missing banner.
+			const banner = plugin.banners?.high;
+			if (
+				typeof banner !== 'string' ||
+				! /^(https?:)?\/\//.test( banner )
+			) {
+				return null;
+			}
+
+			return {
+				id: `plugin-${ plugin.slug }`,
+				url: banner.replace( /^\/\//, 'https://' ),
+				title: `${ plugin.name } (plugin banner)`,
+				pageUrl: `https://wordpress.org/plugins/${ plugin.slug }/`,
+				credit: plugin.author_profile || plugin.author,
+				license:
+					'Plugin author artwork; referenced by URL, not vendored',
+				source: 'WordPress Plugin Directory',
+				subject: 'logo-on-flat',
+			};
+		} )
+		.filter( Boolean )
+		.slice( 0, count );
+}
+
+export const SOURCES = {
+	photos: {
+		label: 'WordPress Photo Directory',
+		collect: fromPhotoDirectory,
+		// Most of a run should be photographs, because that is most of what
+		// gets uploaded and where a better crop actually helps.
+		share: 0.6,
+	},
+	themes: {
+		label: 'Theme screenshots',
+		collect: fromThemeScreenshots,
+		share: 0.2,
+	},
+	plugins: {
+		label: 'Plugin banners',
+		collect: fromPluginBanners,
+		share: 0.2,
+	},
+};
+
+/**
+ * Builds a mixed corpus across the enabled sources.
+ *
+ * @param {Object}   options
+ * @param {number}   options.count   Total number of images.
+ * @param {string[]} options.sources Source keys to draw from.
+ * @param {Function} options.rng     Random number generator returning 0..1.
+ * @param {Function} options.onLog   Progress reporter.
+ * @return {Promise<Array>} Corpus entries.
+ */
+export async function buildCorpus( { count, sources, rng, onLog } ) {
+	const enabled = sources.filter( ( key ) => SOURCES[ key ] );
+	const totalShare = enabled.reduce(
+		( sum, key ) => sum + SOURCES[ key ].share,
+		0
+	);
+
+	const collected = [];
+
+	for ( const [ index, key ] of enabled.entries() ) {
+		const source = SOURCES[ key ];
+		// The last source absorbs the rounding remainder so the run hits `count`.
+		const wanted =
+			index === enabled.length - 1
+				? count - collected.length
+				: Math.round( ( count * source.share ) / totalShare );
+
+		if ( wanted <= 0 ) {
+			continue;
+		}
+
+		onLog( `Collecting ${ wanted } from ${ source.label }…` );
+
+		try {
+			collected.push( ...( await source.collect( wanted, rng ) ) );
+		} catch ( error ) {
+			onLog( `  ! ${ source.label } failed: ${ error.message }` );
+		}
+	}
+
+	return collected;
+}
+
+/**
+ * Downloads an image.
+ *
+ * @param {string} url Image URL.
+ * @return {Promise<Uint8Array>} Image bytes.
+ */
+export async function download( url ) {
+	const response = await fetch( url, {
+		headers: { 'user-agent': USER_AGENT },
+	} );
+
+	if ( ! response.ok ) {
+		throw new Error( `${ response.status } ${ response.statusText }` );
+	}
+
+	return new Uint8Array( await response.arrayBuffer() );
+}


### PR DESCRIPTION
_Claude built this one end to end, description included:_

**Not for merge.** This is a measurement tool for the discussion in https://github.com/WordPress/gutenberg/issues/81706, parked on a branch so the numbers behind any claim about `attention` can be reproduced rather than asserted.

The thread so far has compared specifications rather than pictures. Whether `attention` positions a hard crop better than `centre` is a claim about output quality, and there is currently no way to check it - the image fixtures in the tree are format coverage files, not photos with a subject to miss.

```sh
node tools/smart-crop-corpus/index.mjs
```

That assembles a fresh corpus, crops every image both ways, and writes a self-contained HTML report where you grade each pair thumbs up or thumbs down. Every run picks a different set of images; pass the seed it prints back in with `--seed` to get the same set again.

### Where the images come from

Nothing is vendored. Each run fetches from public endpoints and records the URLs in the manifest, so licensing stays with the original hosts.

- WordPress Photo Directory, ~43,000 CC0 photos submitted by the community, via https://wordpress.org/photos/wp-json/wp/v2/photos. The closest public stand-in for what people actually upload.
- Theme directory screenshots. Flat regions, dense text, a subject filling the frame. Nothing like a photograph.
- Plugin directory banners. Logos on flat backgrounds, which is the failure class open question 5 calls out.

The Photo Directory is 63% `nature` and 3.8% `people`. Sampling it proportionally would mostly grade landscapes, which is the case centre cropping already handles fine, so the harness weights toward subjects that have a subject to miss.

### What it crops

For a standard 8-bit image, `applyResizeAndCrop()` in `packages/vips` reduces to a single libvips call per size:

```js
vips.Image.thumbnailBuffer( buffer, width, {
	size: 'down',
	height,
	crop: smartCrop ? 'attention' : 'centre',
} );
```

The harness makes exactly that call against the `wasm-vips` build pinned in this repo, so the pixels being graded are the pixels the browser produces. Only the Node entry point of the module differs; the libvips build underneath is the same.

### Signals

libvips returns no confidence score, which the issue names as the crux of the proposal. It does return the attention centre via `attention_x` / `attention_y` on `smartcrop()`, so every row records that plus the three derivations floated in the thread: distance from the image centre, agreement between `attention` and `entropy`, and how far the focal point moves across aspect ratios. Once a run is graded those become the x-axis against a known-good/known-bad y-axis, which is what picking a threshold needs.

One thing already worth noting: the attention centre comes back quantised to a coarse grid, because libvips analyses a heavily shrunk copy. A stored focal point would inherit that precision.

### How has this been tested

1. `npm install`, then `node tools/smart-crop-corpus/index.mjs`
2. Open the `report.html` it prints. Grade a few rows with the buttons or with `1` / `2` / `3`, click a crop to enlarge both.
3. Reload to confirm grades persist, then use "Copy results JSON" to export them.
4. Larger sweep: `node tools/smart-crop-corpus/index.mjs --count 50 --sizes thumbnail,square,wide,tall`

A 50 image run at four sizes produced 189 comparisons with no failures. 30 of those, about 16%, came back with no visible change, meaning attention landed on the centre anyway.

Output goes to `artifacts/smart-crop/<date>-<seed>/`, which is already gitignored. Alongside `report.html` it writes `manifest.json` and the individual crops as files, so an AI reviewer can grade a run by reading them instead of clicking.

### Caveats

- Verdicts are not blind. The reviewer can see which column is which, so this measures preference with knowledge of the condition. Randomising the columns would be the next improvement if the numbers start carrying weight.
- The sources skew toward curated photography and wordpress.org assets. Neither is a random sample of a real media library.
- Grades live in one browser's `localStorage`, so they need exporting.

Related: https://github.com/WordPress/gutenberg/pull/81709

Is a graded run over a few hundred of these enough to settle the confidence threshold question, or does that need the annotated academic cropping sets with ground truth crops as well?

## AI Use

Code and description both written with 🤖 Claude Code. I will review and test.
